### PR TITLE
Merge catch blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ AMSAT Fox-1 Telemetry Decoder
 
  @author chris.e.thompson g0kla/ac2cz
  
- Copyright (C) 2015 amsat.org
+ Copyright (C) 2015-2019 amsat.org
 
  This program is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/src/telemetry/Frame.java
+++ b/src/telemetry/Frame.java
@@ -496,12 +496,8 @@ public abstract class Frame implements Comparable<Frame> {
 							stpDateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 							try {
 								stpDate = stpDateFormat.parse(dt);
-							} catch (ParseException e) {
-								Log.println("ERROR - Date was not parsable. Setting to null"  + "\n" + e.getMessage());
-								stpDate = null;
-								//e.printStackTrace(Log.getWriter());
-							} catch (NumberFormatException e) {
-								Log.println("ERROR - Date has number format exception. Setting to null"  + "\n" + e.getMessage());
+							} catch (ParseException | NumberFormatException e) {
+								Log.println("ERROR - Date was not parsable. Setting to null"  + "\n" + e.getClass() + "\n" + e.getMessage());
 								stpDate = null;
 							} catch (Exception e) { // we can get other unusual exceptions such as ArrayIndexOutOfBounds...
 								Log.println("ERROR - Date was not parsable. Setting to null: " + e.getMessage());


### PR DESCRIPTION
Merges the NumberFormatException and ParseException catch blocks; logs the exception's runtime class so that no information is lost. (In fact, if either ParseException or NumberFormatException is subclassed, this change *increases* the information that's logged.)