### PR TITLE
Allow use of RTL2832

### DIFF
--- a/src/gui/SourceTab.java
+++ b/src/gui/SourceTab.java
@@ -1942,6 +1942,23 @@ public class SourceTab extends JPanel implements Runnable, ItemListener, ActionL
 							rfDevice = null;
 						}
 					} 
+					if (rfDevice == null) { // this is a hack to try connecting to different versions (RTL2832) of the RTL-SDR that have a different product id FIXME
+						if (position-soundcardSources.length == 0) {
+							vendorId = (short)0x0BDA;
+							deviceId = (short)0x2832;
+						} 
+						try {
+							rfDevice = tunerManager.findDevice(vendorId, deviceId, sampleRate);
+						} catch (UsbException e1) {
+							Log.errorDialog("ERROR", "USB Issue trying to open device:\n" + e1.getMessage());
+							e1.printStackTrace();
+							rfDevice = null;
+						} catch (DeviceException e) {
+							Log.errorDialog("ERROR", "Device could not be opened:\n" + e.getMessage());
+							e.printStackTrace();
+							rfDevice = null;
+						}
+					} 
 					if (rfDevice == null) {
 						Log.errorDialog("Missing USB device", "Insert the device or choose anther source");
 						stopButton();


### PR DESCRIPTION
I have a few Nooelec SMArt SDR devices (which outperform most of the other RTL-SDRs I've compared it to) and they use the RTL2832U / E4000, they are not currently detected by FoxTelem, but seem to work great on Windows if I change the device id to 0x2832.

This PR tries that device id after it doesn't find a device with the existing device id of 0x2838. It would probably be better to refactor findDevice to take in an array of vendor/device ids, but getting this simple fix in will allow me to test within Fox-In-A-Box.